### PR TITLE
Error response

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -236,8 +236,10 @@ app.get("/hc", (req, res) => {
 
   app.use(function (err: any, req: any, res: any, next: any) {
     logger.error(err); // Log error message in our server's console
-    if (!err.statusCode) err.statusCode = 500; // If err has no specified error code, set error code to 'Internal Server Error (500)'
-    res.status(err.statusCode).send(err); // All HTTP requests must have a response, so let's send back an error with its status
+    // We don't want to mutate actuall error message
+    const statusCode = err.statusCode || 500; // If err has no specified error code, set error code to 'Internal Server Error (500)'
+    const errorMessage = err.message || err.toString() || "Unknown error";
+    res.status(statusCode).send({ statusCode, message: errorMessage }); // All HTTP requests must have a response, so let's send back an error with its status
   });
 
   app.listen(port, () => {


### PR DESCRIPTION
# Fixes

## Error response
Currently, error reporting middleware will always respond as follows
 ```
{ statusCode: 500 }`
```
Reason is that `Error` object doesn't have any enumerable parameters.
This PR adds error message to the object explicitly.

## Tolk verifier test

Tolk verifier test is updated to the modern code (Tolk v1) and `DynamicImporter`
in order to verify that there is no issues in that regard.