### PR TITLE
Ipfs provider

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 SOURCES_REGISTRY=EQD-BJSVUJviud_Qv7Ymfd3qzXdrmV525e3YDzWQoHIAiInL
 VERIFIER_ID=orbs.com
 IPFS_PROVIDER=tonsource.infura-ipfs.io
+IPFS_API=https://ipfs.infura.io:5001/api/v0
 COMPILE_TIMEOUT=5000
 LEGACY_FUNC_COMPILER=false

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 SOURCES_REGISTRY=EQD-BJSVUJviud_Qv7Ymfd3qzXdrmV525e3YDzWQoHIAiInL
 VERIFIER_ID=orbs.com
-IPFS_PROVIDER=tonsource.infura-ipfs.io
+IPFS_PROVIDER=https://tonsource.infura-ipfs.io
 IPFS_API=https://ipfs.infura.io:5001/api/v0
 COMPILE_TIMEOUT=5000
 LEGACY_FUNC_COMPILER=false

--- a/src/ipfs-code-storage-provider.ts
+++ b/src/ipfs-code-storage-provider.ts
@@ -71,7 +71,7 @@ export class IpfsCodeStorageProvider implements CodeStorageProvider {
 
   async read(pointer: string): Promise<string> {
     return (
-      await fetch(`https://${process.env.IPFS_PROVIDER}/ipfs/${pointer.replace("ipfs://", "")}`)
+      await fetch(`${process.env.IPFS_PROVIDER}/ipfs/${pointer.replace("ipfs://", "")}`)
     ).text();
   }
 }

--- a/src/ipfs-code-storage-provider.ts
+++ b/src/ipfs-code-storage-provider.ts
@@ -24,9 +24,10 @@ export class IpfsCodeStorageProvider implements CodeStorageProvider {
 
   constructor(infuraId: string, infuraSecret: string) {
     const auth = "Basic " + Buffer.from(infuraId + ":" + infuraSecret).toString("base64");
+    const url = new URL(process.env.IPFS_API!);
 
     this.#client = create({
-      url: "https://ipfs.infura.io:5001/api/v0",
+      url: url.toString(),
       headers: {
         authorization: auth,
       },

--- a/src/latest-known-contracts.ts
+++ b/src/latest-known-contracts.ts
@@ -116,7 +116,7 @@ async function update(verifierIdSha256: Buffer, ipfsProvider: string) {
         let ipfsData;
         try {
           ipfsData = await axios.get(
-            `https://${ipfsProvider}/ipfs/${ipfsLink.replace("ipfs://", "")}`,
+            `${ipfsProvider}/ipfs/${ipfsLink.replace("ipfs://", "")}`,
             { timeout: 3000 },
           );
         } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,15 +136,20 @@ app.get("/hc", (req, res) => {
   };
 
   const deployController = new DeployController(
-    new IpfsCodeStorageProvider(
-      process.env.TACT_DEPLOYER_INFURA_ID!,
-      process.env.TACT_DEPLOYER_INFURA_SECRET!,
-    ),
+    new IpfsCodeStorageProvider({
+      type: "basic",
+      username: process.env.TACT_DEPLOYER_INFURA_ID!,
+      password: process.env.TACT_DEPLOYER_INFURA_SECRET!,
+    }),
     fileSystem,
   );
 
   const controller = new Controller(
-    new IpfsCodeStorageProvider(process.env.INFURA_ID!, process.env.INFURA_SECRET!),
+    new IpfsCodeStorageProvider({
+      type: "basic",
+      username: process.env.INFURA_ID!,
+      password: process.env.INFURA_SECRET!,
+    }),
     {
       func:
         process.env.LEGACY_FUNC_COMPILER === "true"

--- a/src/ton-reader-client.ts
+++ b/src/ton-reader-client.ts
@@ -43,9 +43,11 @@ export async function getTonClient(): Promise<LiteClient> {
 
 async function createClient(): Promise<LiteClient> {
   const isTestnet = process.env.NETWORK === "testnet";
-  const configUrl = isTestnet
-    ? "https://ton.org/testnet-global.config.json"
-    : "https://ton.org/global.config.json";
+  const configUrl =
+    process.env.LITESERVER_CONFIG_URL ??
+    (isTestnet
+      ? "https://ton.org/testnet-global.config.json"
+      : "https://ton.org/global.config.json");
 
   console.log("Using config URL:" + configUrl);
 


### PR DESCRIPTION
# Features

- Get's rid of hardcoded ipfs related constats for patch-less provider migration.
- Allows full schema specification for `IPFS_PROVIDER` env (for local nodes and such).
- Adds support for arbitrary custom token auth (Bearer,..).
- Separates API endpoint form gateway endpoint.
- Adds ability to override `LITESERVER_CONFIG_URL` for testing with [MyLocalTON](https://github.com/neodix42/mylocalton-docker) for example